### PR TITLE
Permitir carregamento de fonte dos ícones

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ gem "middleman-blog"
 gem "middleman-livereload", :github => "middleman/middleman-livereload"
 gem "nokogiri"
 gem "therubyracer"
+
+gem 'rack-cors', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
     padrino-support (0.12.2)
       activesupport (>= 3.1)
     rack (1.5.2)
+    rack-cors (0.2.9)
     rack-livereload (0.3.15)
       rack
     rack-test (0.6.2)
@@ -140,4 +141,5 @@ DEPENDENCIES
   middleman-gh-pages
   middleman-livereload!
   nokogiri
+  rack-cors
   therubyracer

--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,11 @@
+require 'rack/cors'
+use Rack::Cors do
+  allow do
+    origins '*'
+    resource '*', headers: :any, methods: :get
+  end
+end
+
 ###
 # Blog settings
 ###


### PR DESCRIPTION
Temos problema para carregar fontes de fora em alguns navegadores, o servidor da fonte deve enviar um header http para poder carregar.

Este código faz isso.
